### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Web/App.pm6
+++ b/lib/Web/App.pm6
@@ -1,4 +1,4 @@
-class Web::App;
+unit class Web::App;
 
 use Web::App::Context;
 

--- a/lib/Web/App/Context.pm6
+++ b/lib/Web/App/Context.pm6
@@ -1,4 +1,4 @@
-class Web::App::Context;
+unit class Web::App::Context;
 
 ## This is a special object returned to Web::App handlers, which contains
 ## a bunch of magic wrapper functions, to make life easier.

--- a/lib/Web/App/Dispatch.pm6
+++ b/lib/Web/App/Dispatch.pm6
@@ -1,6 +1,6 @@
 use Web::App;
 
-class Web::App::Dispatch is Web::App;
+unit class Web::App::Dispatch is Web::App;
 
 use Web::App::Context;
 

--- a/lib/Web/Request.pm6
+++ b/lib/Web/Request.pm6
@@ -1,4 +1,4 @@
-class Web::Request;
+unit class Web::Request;
 
 use Web::Request::Multipart; ## Multipart context parsers.
 use Web::Request::File;      ## Uploaded files.

--- a/lib/Web/Request/File.pm6
+++ b/lib/Web/Request/File.pm6
@@ -1,4 +1,4 @@
-class Web::Request::File;
+unit class Web::Request::File;
 
 ## Represents an uploaded file.
 

--- a/lib/Web/Request/Multipart.pm6
+++ b/lib/Web/Request/Multipart.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Web::Request::Multipart;
+unit class Web::Request::Multipart;
 
 use Web::Request::File;
 

--- a/lib/Web/Response.pm6
+++ b/lib/Web/Response.pm6
@@ -1,4 +1,4 @@
-class Web::Response;
+unit class Web::Response;
 
 has $.status is rw;
 has @.headers;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.