### PR TITLE
Fix calling pop on immutable list

### DIFF
--- a/lib/Web/App.pm6
+++ b/lib/Web/App.pm6
@@ -1,6 +1,7 @@
 unit class Web::App;
 
 use Web::App::Context;
+use MIME::Types;
 
 has $.engine; ## The engine to handle requests.
 has $!mime;   ## MIME::Types object. Initialized on first use of mime().

--- a/lib/Web/App/Context.pm6
+++ b/lib/Web/App/Context.pm6
@@ -53,7 +53,7 @@ method send-file ($filename, :$file, :$content, :$type, Bool :$cache) {
   my $ctype;
   if $type { $ctype = $type; }
   else {
-    my $ext = $filename.split('.').pop;
+    my $ext = $filename.split('.')[*-1] || '';
     $ctype = $.app.mime.type($ext);
     if (!$ctype) {
       $ctype = 'application/octet-stream';


### PR DESCRIPTION
Calling `pop` using rakudo-star on OS X causes a runtime error, so I changed it to reference the last element in the list instead.

Also, calling `load-mime` externally (for use on systems without `/etc/mime.types`) would give an error saying that `&Types` is not found unless the `use` statement is added.