### PR TITLE
Allow auto content-length for Buf body

### DIFF
--- a/lib/Web/Response.pm6
+++ b/lib/Web/Response.pm6
@@ -74,7 +74,10 @@ method response
 {
   if $.auto-length
   {
-    my $len = @.body.join.encode.bytes;
+    my $len = [+] @.body.map({
+      when Buf { .bytes }
+      default  { .encode.bytes }
+    });
     self.insert-header('Content-Length' => $len);
   }
   my $headers = @.headers;


### PR DESCRIPTION
The existing way of calculating length will cast each element of `@.body` to a `Str`, which will give invalid utf-8 errors on `Buf`s of binary data like images sent from `send-file`.