### PR TITLE
Updates configuration and README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: perl6
 
 perl6:
     - latest
+    - 2017.01
     - 2016.01
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ perl6:
 
 install:
     - rakudobrew build-zef
-    - zef update && zef install PSGI MIME::Types HTTP::Easy::PSGI FastCGI SCGI
+    - zef update && zef install --deps-only .
 script:
     - PERL6LIB=lib prove -v -r --ext p6 --exec=perl6 test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
-language: perl6
-
-perl6:
-    - latest
-    - 2017.01
-    - 2016.01
+services:
+  - docker
 
 install:
-    - rakudobrew build-zef
-    - zef update && zef install --deps-only .
-script:
-    - PERL6LIB=lib prove -v -r --ext p6 --exec=perl6 test/
+  - docker pull jjmerelo/test-perl6
+  - docker images
+  - docker run -t --entrypoint="/bin/sh" jjmerelo/test-perl6 -c "perl6 --version; which zef "
+
+script: 
+  - docker run -t -v  $TRAVIS_BUILD_DIR:/test jjmerelo/test-perl6
+

--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
   "name"        : "Web",
   "version"     : "0.9.2",
   "description" : "A Web Application foundation for Perl 6",
-  "depends"     : [ "MIME::Types", "PSGI", "SCGI" ],
+    "depends"     : [ "MIME::Types", "PSGI", "SCGI", "FastCGI", "HTTP::Easy::PSGI" ],
   "provides"    : {
     "Web::App"                : "lib/Web/App.pm6",
     "Web::App::Context"       : "lib/Web/App/Context.pm6",

--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ HTTP::Easy's PSGI adapter, without using Web::App as a wrapper.
 For more examples, including using other backends, more dispatch
 rules, and lots of other cool stuff, see the examples in the 'test' folder.
 
+## Install
+
+Install directly from this repo using
+
+	zef install Web
+
+or download this repo and do
+
+	zef install --deps-only .
+
+if you want to try and contribute to it. 
+
 ## TODO
 
   * Finish testing framework, and write some tests.


### PR DESCRIPTION
Travis will take the configuration from META6.json and use `zef` to install upstream dependencies. Changes the travis config to a Docker-based one (no versions)