### PR TITLE
fix problems with bless

### DIFF
--- a/lib/Web/Request.pm6
+++ b/lib/Web/Request.pm6
@@ -133,7 +133,7 @@ method new(%env, :$allow-cgi) {
       %new<body> = $*IN.slurp;
     }
   }
-  return self.bless(*, |%new)!initialize();
+  return self.bless(|%new)!initialize();
 }
 
 method !initialize {


### PR DESCRIPTION
This change fixes the following problem when running the CGI-Example from perl6-examples within my Rakudo-Star 2018.01 Docker-Container:
```
root@perl6-mvc:/workdir/perl6-examples/categories/cookbook/19cgi-programming# perl6 19-01cgi-script.pl 
[2018-03-09T08:22:19Z] Started HTTP server.
[2018-03-09T08:22:27Z] GET / HTTP/1.1
Too many positionals passed; expected 1 argument but got 2
  in method new at /usr/share/perl6/site/sources/3BD07F2EEF8461A0B54CA9763FBD54A341C59873 (Web::Request) line 136
  in sub  at 19-01cgi-script.pl line 34
  […]
  in block <unit> at 19-01cgi-script.pl line 45
```

I'm quite experienced in programming Perl5, but a novice in Perl6, so please, double-check if the change doesn't break anything.